### PR TITLE
Add Sendable conformance to Xoshiro and LCRNG generators

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.5
 import Foundation
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.0
 import Foundation
 import PackageDescription
 

--- a/Sources/Gen/LCRNG.swift
+++ b/Sources/Gen/LCRNG.swift
@@ -4,7 +4,7 @@
   message:
     "LCRNG has been deprecated due to instability across Swift versions. Use Xoshiro for seedable randomness, instead."
 )
-public struct LCRNG: RandomNumberGenerator {
+public struct LCRNG: RandomNumberGenerator, Sendable {
   public var seed: UInt64
 
   @inlinable

--- a/Sources/Gen/LCRNG.swift
+++ b/Sources/Gen/LCRNG.swift
@@ -4,7 +4,7 @@
   message:
     "LCRNG has been deprecated due to instability across Swift versions. Use Xoshiro for seedable randomness, instead."
 )
-public struct LCRNG: RandomNumberGenerator, Sendable {
+public struct LCRNG: RandomNumberGenerator {
   public var seed: UInt64
 
   @inlinable
@@ -18,3 +18,7 @@ public struct LCRNG: RandomNumberGenerator, Sendable {
     return seed
   }
 }
+
+#if swift(>=5.5)
+extension LCRNG: Sendable {}
+#endif

--- a/Sources/Gen/Xoshiro.swift
+++ b/Sources/Gen/Xoshiro.swift
@@ -1,5 +1,5 @@
 /// An implementation of xoshiro256**: http://xoshiro.di.unimi.it.
-public struct Xoshiro: RandomNumberGenerator, Sendable {
+public struct Xoshiro: RandomNumberGenerator {
   @usableFromInline
   var state: (UInt64, UInt64, UInt64, UInt64)
 
@@ -52,3 +52,7 @@ extension Xoshiro {
     state
   }
 }
+
+#if swift(>=5.5)
+extension Xoshiro: Sendable {}
+#endif

--- a/Sources/Gen/Xoshiro.swift
+++ b/Sources/Gen/Xoshiro.swift
@@ -1,5 +1,5 @@
 /// An implementation of xoshiro256**: http://xoshiro.di.unimi.it.
-public struct Xoshiro: RandomNumberGenerator {
+public struct Xoshiro: RandomNumberGenerator, Sendable {
   @usableFromInline
   var state: (UInt64, UInt64, UInt64, UInt64)
 


### PR DESCRIPTION
The current implementation of `swift-gen` supports back to swift 5.0. However, with the release of swift 6.0 the Sendability requirements have become more strict. An example for this project is using the generators with the `withRandomNumberGenerator` dependency in the `swift-dependencies` [package](https://github.com/pointfreeco/swift-dependencies). Using e.g. Xoshiro raises an error:
```swift
withDependencies {
  $0.withRandomNumberGenerator = WithRandomNumberGenerator(Xoshiro(seed: 0))
// Type 'Xoshiro' does not conform to the 'Sendable' protocol 👆
}
```
All that's required is the declaration for the included generators to support sendability.